### PR TITLE
 [resolves issue #14] Org object data caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ __pycache__
 .cache/
 .pytest_cache
 .~c9*
+.coverage
+.coverage.*
+notes
+docs/_build

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ before_install:
   - cat /etc/issue
 install:
   - pip install .
-  - pip install https://github.com/ashleygould/moto/archive/ashley.zip
+  - pip install https://github.com/spulec/moto/archive/master.zip
   - pip install -r requirements.txt
 script: 
   - flake8 organizer

--- a/doc/issues
+++ b/doc/issues
@@ -1,0 +1,43 @@
+(python3.6) agould@horus:~/git-repos/github/ucopacme/organizer/test> time organizer awsauth/OrgAdmin list_accounts
+Exception in thread Thread-24:
+Traceback (most recent call last):
+  File "/usr/local/lib/python3.6/threading.py", line 916, in _bootstrap_inner
+    self.run()
+  File "/usr/local/lib/python3.6/threading.py", line 864, in run
+    self._target(*self._args, **self._kwargs)
+  File "/home/agould/git-repos/github/ucopacme/organizer/organizer/utils.py", line 64, in worker
+    func(item, *args)
+  File "/home/agould/git-repos/github/ucopacme/organizer/organizer/orgs.py", line 151, in make_org_account_object
+    response = org.client.list_parents(ChildId=account['Id'])
+  File "/home/agould/python-venv/python3.6/lib/python3.6/site-packages/botocore/client.py", line 314, in _api_call
+    return self._make_api_call(operation_name, kwargs)
+  File "/home/agould/python-venv/python3.6/lib/python3.6/site-packages/botocore/client.py", line 612, in _make_api_call
+    raise error_class(parsed_response, operation_name)
+botocore.errorfactory.TooManyRequestsException: An error occurred (TooManyRequestsException) when calling the ListParents operation (reached max retries: 4): AWS Organizations can't complete your request because another request is already in progress. Try again later.
+
+^CTraceback (most recent call last):
+  File "/home/agould/git-repos/github/ucopacme/organizer/organizer/orgs.py", line 95, in load
+    org_dump = self._load_org_pickle_from_file()
+  File "/home/agould/git-repos/github/ucopacme/organizer/organizer/orgs.py", line 111, in _load_org_pickle_from_file
+    raise RuntimeError('Pickle file not found')
+RuntimeError: Pickle file not found
+
+During handling of the above exception, another exception occurred:
+
+Traceback (most recent call last):
+  File "/home/agould/python-venv/python3.6/bin/organizer", line 11, in <module>
+    load_entry_point('organizer', 'console_scripts', 'organizer')()
+  File "/home/agould/git-repos/github/ucopacme/organizer/organizer/cli.py", line 90, in main
+    org.load()
+  File "/home/agould/git-repos/github/ucopacme/organizer/organizer/orgs.py", line 101, in load
+    self._load_accounts()
+  File "/home/agould/git-repos/github/ucopacme/organizer/organizer/orgs.py", line 165, in _load_accounts
+    thread_count=len(accounts)
+  File "/home/agould/git-repos/github/ucopacme/organizer/organizer/utils.py", line 73, in queue_threads
+    q.join()
+  File "/usr/local/lib/python3.6/queue.py", line 83, in join
+    self.all_tasks_done.wait()
+  File "/usr/local/lib/python3.6/threading.py", line 295, in wait
+    waiter.acquire()
+KeyboardInterrupt
+

--- a/organizer/cli.py
+++ b/organizer/cli.py
@@ -5,16 +5,17 @@ Script for querying AWS Organization resources
 
 Usage:
     organizer [-h]
-    organizer [-f FORMAT] ROLE COMMAND [ARGUMENT]
+    organizer [-f format] [-m master_account_id] -r role COMMAND [ARGUMENT]
 
 Arguments:
-    ROLE        The AWS role name to assume when running organizer
     COMMAND     An organizer query command to run
     ARGUMENT    A command argument to supply if needed
 
 Options:
     -h, --help              Print help message
-    -f, --format FORMAT     Output format:  "json" or "yaml". [Default: json]
+    -f format               Output format:  "json" or "yaml". [Default: json]
+    -m master_account_id    The master account id for the organization
+    -r role                 The AWS role name to assume when running organizer
 
 Available Query Commands:
     dump
@@ -77,16 +78,20 @@ def main():
     if args['COMMAND'] in _COMMANDS_WITH_ARG and not args['ARGUMENT']:
         print('ERROR: Query command "{}" requires an argument'.format(args['COMMAND']))
         sys.exit(__doc__)
-    if args['--format'] == 'json':
+    if args['-f'] == 'json':
         formatter = utils.jsonfmt
-    elif args['--format'] == 'yaml':
+    elif args['-f'] == 'yaml':
         formatter = utils.yamlfmt
     else:
         print('ERROR: Print format must be either "json" or "yaml"')
         sys.exit(__doc__)
 
-    master_account_id = get_master_account_id(args['ROLE'])
-    org = orgs.Org(master_account_id, args['ROLE'])
+    if args['-m'] is None:
+        master_account_id = get_master_account_id(args['-r'])
+    else:
+        master_account_id = args['-m']
+
+    org = orgs.Org(master_account_id, args['-r'])
     org.load()
     cmd = eval('org.' + args['COMMAND'])
     if args['ARGUMENT']:

--- a/organizer/orgs.py
+++ b/organizer/orgs.py
@@ -222,7 +222,6 @@ class Org(object):
     def get_org_unit_id_by_name(self, name):
         return next((ou.id for ou in self.org_units if ou.name == name), None)
 
-    # NO TEST
     def _check_if_org_unit_name(self, ou_id):
         if ou_id == 'root':
             return self.root_id

--- a/test/test_orgs.py
+++ b/test/test_orgs.py
@@ -341,7 +341,7 @@ def test_get_account_id_by_name():
  
 @mock_sts
 @mock_organizations
-def test_get_account_id_by_name():
+def test_get_account_name_by_id():
     org_id, root_id = build_mock_org(SIMPLE_ORG_SPEC)
     org = orgs.Org(MASTER_ACCOUNT_ID, ORG_ACCESS_ROLE)
     org.load()
@@ -366,6 +366,19 @@ def test_get_org_unit_id_by_name():
     assert ou_id == next((
         ou['Id'] for ou in ou_by_boto_client if ou['Name'] == 'ou02'
     ), None)
+    clean_up()
+
+ 
+@mock_sts
+@mock_organizations
+def test__check_if_org_unit_name():
+    org_id, root_id = build_mock_org(SIMPLE_ORG_SPEC)
+    org = orgs.Org(MASTER_ACCOUNT_ID, ORG_ACCESS_ROLE)
+    org.load()
+    ou = org.org_units[0]
+    assert org._check_if_org_unit_name(ou.id) == ou.id
+    assert org._check_if_org_unit_name(ou.name) == ou.id
+    assert org._check_if_org_unit_name('root') == org.root_id
     clean_up()
 
  

--- a/test/test_orgs.py
+++ b/test/test_orgs.py
@@ -265,6 +265,7 @@ def test_load():
     org_from_pickle_file = orgs.Org(MASTER_ACCOUNT_ID, ORG_ACCESS_ROLE)
     org_from_pickle_file.load()
     assert org.dump() == org_from_pickle_file.dump()
+    clean_up()
 
  
 @mock_sts
@@ -293,6 +294,7 @@ def test_list_accounts():
     assert len(response) == 3
     for account_id in response:
         assert re.compile(r'[0-9]{12}').match(account_id)
+    clean_up()
 
 @mock_sts
 @mock_organizations
@@ -320,6 +322,7 @@ def test_list_org_units():
     assert len(response) == 6
     for ou_id in response:
         assert ou_id.startswith('ou-')
+    clean_up()
 
  
 @mock_sts
@@ -333,6 +336,7 @@ def test_get_account_id_by_name():
     assert account_id == next((
         a['Id'] for a in accounts_by_boto_client if a['Name'] == 'account01'
     ), None)
+    clean_up()
 
  
 @mock_sts
@@ -347,6 +351,7 @@ def test_get_account_id_by_name():
     assert account_name == next((
         a['Name'] for a in accounts_by_boto_client if a['Id'] == account_id
     ), None)
+    clean_up()
 
  
 @mock_sts
@@ -361,6 +366,7 @@ def test_get_org_unit_id_by_name():
     assert ou_id == next((
         ou['Id'] for ou in ou_by_boto_client if ou['Name'] == 'ou02'
     ), None)
+    clean_up()
 
  
 @mock_sts
@@ -386,6 +392,7 @@ def test_list_accounts_in_ou():
 
     response = org.list_accounts_in_ou_by_id(ou_id)
     assert sorted(response) == sorted([a['Id'] for a in accounts_by_boto_client])
+    clean_up()
 
  
 @mock_sts
@@ -426,6 +433,7 @@ def test_list_accounts_under_ou():
     assert len(response) == 5
     for account_id in response:
         assert re.compile(r'[0-9]{12}').match(account_id)
+    clean_up()
 
 
 @mock_sts

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -2,11 +2,11 @@ import re
 import time
 import json
 import yaml
+import pytest
 
 import boto3
 from botocore.exceptions import ClientError
 from moto import mock_sts, mock_organizations
-import pytest
 
 from organizer import utils
 from .test_orgs import SIMPLE_ORG_SPEC
@@ -70,7 +70,7 @@ def test_regions_for_service():
     assert 'us-east-1' in regions
     regions = utils.regions_for_service('iam')
     assert regions ==  []
-    with pytest.raises(Exception) as e:
+    with pytest.raises(Exception):
         regions = utils.regions_for_service('blee')
     all_regions = utils.all_regions()
     assert all_regions == utils.regions_for_service('ec2')


### PR DESCRIPTION
Org.load() checks for an existing cache_file.  If less than self.cache_file_max_age, load data from cached org dump.  this cuts org object load time by about 4.5 seconds.  no credentials are cached.  default expire is 1 hour.